### PR TITLE
Account fix

### DIFF
--- a/GroupUp-Backend/src/main/java/ca/mcgill/ecse428/groupup/controller/AccountController.java
+++ b/GroupUp-Backend/src/main/java/ca/mcgill/ecse428/groupup/controller/AccountController.java
@@ -6,14 +6,13 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import ca.mcgill.ecse428.groupup.dto.AccountDTO;
-import ca.mcgill.ecse428.groupup.dto.CourseDTO;
 import ca.mcgill.ecse428.groupup.model.Account;
 import ca.mcgill.ecse428.groupup.model.Admin;
-import ca.mcgill.ecse428.groupup.model.Course;
 import ca.mcgill.ecse428.groupup.model.Student;
 import ca.mcgill.ecse428.groupup.service.AccountService;
 
@@ -46,18 +45,19 @@ public class AccountController {
         return DTOUtil.convertToDTO(acc);
     }
 
-    @PostMapping(value ={"/account/update", "/account/update/"})
-    public AccountDTO changeUserInformation(@RequestParam("email") String oldEmail,
-                                            @RequestParam("newUserName") String newUserName,
-                                            @RequestParam("newName") String newName,
-                                            @RequestParam("newEmail") String newEmail,
-                                            @RequestParam("newInstitution") String newInstitution)
+    //This method allows users to change all information except their password
+    @PutMapping(value ={"/account/update", "/account/update/"})
+    public AccountDTO changeUserInformation(@RequestParam(value = "email", required = true) String oldEmail,
+                                            @RequestParam(value = "newUserName",required = false) String newUserName,
+                                            @RequestParam(value = "newName", required = false) String newName,
+                                            @RequestParam(value = "newEmail", required = false) String newEmail,
+                                            @RequestParam(value = "newInstitution",required = false) String newInstitution)
         throws IllegalArgumentException {
     Account acc = accountService.changeUserInformation(oldEmail, newUserName, newName, newEmail,
                                                     newInstitution);
     return DTOUtil.convertToDTO(acc);
     }
-    
+
     @PostMapping(value ={"/Login/","/Login/"})
     public AccountDTO LogIn (@RequestParam("email")String email,
                             @RequestParam("password")String password)

--- a/GroupUp-Backend/src/main/java/ca/mcgill/ecse428/groupup/dto/AccountDTO.java
+++ b/GroupUp-Backend/src/main/java/ca/mcgill/ecse428/groupup/dto/AccountDTO.java
@@ -5,17 +5,17 @@ public class AccountDTO {
     String userRole;
     String userName;
     String name;
-    String email;
-    String institution;
+    String userEmail;
+    String userInstitution;
 
     public AccountDTO() {};
 
-    public AccountDTO(String userRole, String userName, String name, String email, String institution) {
+    public AccountDTO(String userRole, String userName, String name, String userEmail, String userInstitution) {
         this.userRole = userRole;
         this.userName = userName;
         this.name = name;
-        this.email = email;
-        this.institution = institution;
+        this.userEmail = userEmail;
+        this.userInstitution = userInstitution;
     }
 
     public String getUserRole() {
@@ -39,17 +39,17 @@ public class AccountDTO {
         this.name = name;
     }
 
-    public String getEmail() {
-        return email;
+    public String getUserEmail() {
+        return userEmail;
     }
-    public void setEmail(String email) {
-        this.email = email;
+    public void setUserEmail(String userEmail) {
+        this.userEmail = userEmail;
     }
 
     public String getUserInstitution() {
-        return institution;
+        return userInstitution;
     }
-    public void setUserInstitution(String institution) {
-        this.institution = institution;
+    public void setUserInstitution(String userInstitution) {
+        this.userInstitution = userInstitution;
     }
 }

--- a/GroupUp-Backend/src/main/java/ca/mcgill/ecse428/groupup/service/AccountService.java
+++ b/GroupUp-Backend/src/main/java/ca/mcgill/ecse428/groupup/service/AccountService.java
@@ -10,6 +10,8 @@ import ca.mcgill.ecse428.groupup.dao.AccountRepository;
 import ca.mcgill.ecse428.groupup.dao.AdminRepository;
 import ca.mcgill.ecse428.groupup.dao.StudentRepository;
 import ca.mcgill.ecse428.groupup.model.*;
+import ca.mcgill.ecse428.groupup.utility.Condition;
+
 import org.springframework.transaction.annotation.Transactional;
 
 
@@ -76,32 +78,31 @@ public class AccountService {
         accRepo.save(acc);
         return acc;
     }
-
     @Transactional
     public Account changeUserInformation(String oldEmail, String newUserName,String newName,
                                          String newEmail, String newInstitution)
                                          {
         String error = "";
-        UserRole role = null;
         Account oldAccount = accRepo.findById(oldEmail).orElse(null);
-        if(oldAccount == null){
+        if(!Condition.isValid(oldAccount)){
             error += "No account associated with this email";
-        }else{
-            role = oldAccount.getUserRole();
+            throw new IllegalArgumentException(error);
         }
-        error = verifyInput(role, newUserName, newName, newEmail, newInstitution, "hack"); 
-        if(!oldEmail.equals(newEmail)){
-            error += "You cannot change your email, please enter valid information";
+        oldAccount = setPreliminaryInfo(oldAccount, newUserName, newName);
+        if(Condition.isValid(oldEmail) && Condition.isValid(newEmail)){
+            if(!oldEmail.equals(newEmail)){
+                error += "You cannot change your email, please enter valid information";
+            }
         }
-        if(!oldAccount.getInstitution().equals(newInstitution)){
-            error += "You cannot change your institution as it is linked to your email,"+
-                     " please enter valid information";
+        if(Condition.isValid(newInstitution)){
+            if(!oldAccount.getInstitution().equals(newInstitution)){
+                error += "You cannot change your institution as it is linked to your email,"+
+                    " please enter valid information";
+            }
         }
         if(error.length()>0){
             throw new IllegalArgumentException(error);
         }
-        oldAccount = setAccountDetails(oldAccount, newUserName, newName, newEmail, newInstitution,
-                                    "hack");
         accRepo.save(oldAccount);
         return oldAccount;
     }
@@ -157,15 +158,12 @@ public class AccountService {
         return error;
     }
 
-    private Account setAccountDetails(Account acc, String userName,String name,
-                                     String email, String institution, String password)
-                                     {
-        acc.setUserName(userName);
-        acc.setName(name);
-        acc.setEmail(email);
-        acc.setInstitution(institution);
-        if(password != "hack") {
-            acc.setPassword(password);
+    private Account setPreliminaryInfo(Account acc, String newUserName, String newName){
+        if(Condition.isValid(newUserName)){
+            acc.setUserName(newUserName);
+        }
+        if(Condition.isValid(newName)){
+            acc.setName(newName);
         }
         return acc;
     }


### PR DESCRIPTION
- ChangeUserInfo method is now a "PUT" REST Endpoint
- API request parameters are also optional for ChangeUserInfo method. Service method updated accordingly.
- Updates to password will be a future feature, so no additions here.
- Updated AccountDTO to return "userEmail" and "userInstitution" instead of "email" and "institution"
- student name is already being returned by DTO in "name" parameter

PS: While fun, it was a bad idea to rebase off 2 branches in earlier pull request. Reverted changes and branched off backend alone.